### PR TITLE
Don't override sample rate

### DIFF
--- a/src/native_snd.rs
+++ b/src/native_snd.rs
@@ -59,7 +59,6 @@ impl<T: Send + 'static> SoundDriver<T> {
         };
 
         output_format.channels = 2;
-        output_format.sample_rate = SampleRate(44100);
 
         let stream_id = match event_loop.build_output_stream(&device, &output_format) {
             Ok(output_stream) => output_stream,


### PR DESCRIPTION
Upgrading to the latest changes caused it to be unable to play my .wavs, removing the sample rate override seems to fix the issue.
```error : could not build output stream : The requested stream format is not supported by the device.```