### PR TITLE
Fix: wasapi: Crash on alt-tab

### DIFF
--- a/src/wasapi_snd.rs
+++ b/src/wasapi_snd.rs
@@ -163,6 +163,10 @@ unsafe fn audio_thread(mut mixer: crate::mixer::Mixer) {
         }
         let num_frames = dst_buffer_frames - padding;
 
+        if num_frames == 0 {
+            continue;
+        }
+
         let mut wasapi_buffer: *mut u8 = std::ptr::null_mut();
         if (*render_client).GetBuffer(num_frames, &mut wasapi_buffer) < 0 {
             continue;


### PR DESCRIPTION
Fixes issue: https://github.com/not-fl3/quad-snd/issues/26

I get this crash quite often when using macroquad. I looked into this and it looks like the requested num_frames is always 0 when this happens.

This is from [Microsoft docs](https://docs.microsoft.com/en-us/windows/win32/api/audioclient/nf-audioclient-iaudiorenderclient-getbuffer):

> If the caller sets NumFramesRequested = 0, the method returns status code S_OK but does not write to the variable that the ppData parameter points to.