### PR TITLE
Add support for iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # quad-snd
 
-High-level, light-weight, and opinionated audio library. 
+High-level, light-weight, and opinionated audio library.
 
 - [x] Web: WebAudio  
 - [x] Android: OpenSLES  
 - [x] Linux: Alsa  
-- [x] Mac: CoreAudio  
-- [x] Windows: Wasapi   
-- [ ] IOS: CoreAudio(?)  
+- [x] macOS: CoreAudio  
+- [x] Windows: Wasapi
+- [X] iOS: CoreAudio
 
 Being high-level enough allows `quad-snd` to use very different approaches to each backend. For example, for WebAudio all the playback and mixing is based on Audio nodes, while in OpenSLES `quad-snd` itself is responsible for mixing.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ mod snd;
 #[path = "alsa_snd.rs"]
 mod snd;
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 #[path = "coreaudio_snd.rs"]
 mod snd;
 


### PR DESCRIPTION
Feels kinda stupid to open a PR for this, but here we go anyway!

Tested with macroquad (PR coming shortly) on a iPhone 12 Pro Max.

The application was run with the sample iOS miniquad configuration with only one real change, `AudioToolbox.framework` needed to be added to the configuration.