### PR TITLE
Unbreak build on FreeBSD

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ audir-sles = "0.1.0"
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 audrey = { version = "0.3", default-features = false, features = ["wav", "ogg_vorbis"] }
 
-[target.'cfg(target_os = "linux")'.dependencies]
+[target.'cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd"))'.dependencies]
 quad-alsa-sys = "0.3.2"
 libc = "0.2"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ pub use error::Error;
 #[path = "opensles_snd.rs"]
 mod snd;
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd"))]
 #[path = "alsa_snd.rs"]
 mod snd;
 


### PR DESCRIPTION
**alsa-plugins** [contains](https://git.alsa-project.org/?p=alsa-plugins.git;a=tree;f=oss) [OSS](https://en.wikipedia.org/wiki/Open_Sound_System) plugin which is natively supported on DragonFly, FreeBSD and Solaris. Let's follow [cpal](https://github.com/RustAudio/cpal/blob/bf026fe082bff9b373989171713dc83aae97cb5d/Cargo.toml#L34). Runtime tested via [FishFight](https://github.com/fishfight/FishFight) ([package](https://www.freshports.org/games/fishfight)).

```rust
$ cargo build
[...]
error[E0432]: unresolved import `snd`
  --> src/lib.rs:32:9
   |
32 | pub use snd::{AudioContext, Sound};
   |         ^^^ use of undeclared crate or module `snd`
   |
help: there is a crate or module with a similar name
   |
32 | pub use std::{AudioContext, Sound};
   |         ~~~
```
