### PR TITLE
Fast `fill_audio_buffer`

### DIFF
--- a/src/mixer.rs
+++ b/src/mixer.rs
@@ -26,7 +26,7 @@ impl SoundState {
                 *sample
             }
             None if self.looped => {
-                self.sample = 0;
+                self.sample = 1;
                 *sound_data.first()?
             }
             None => return None,


### PR DESCRIPTION
This drops the simple example from about 60µs to about 6-7µs per buffer fill.

Couple notes:
* Zero the buffer ahead of time ([`.fill(0.0)` optimizes to `memset`](https://play.rust-lang.org/?version=stable&mode=release&edition=2021&gist=5d1d9b3833032142fe8997854f92a968)).
* Reversed the nesting of sound_data / buffer iterators, this has two effects:
    * No need to hit the `HashMap` every sample in the buffer.
    * For multiple sounds operating on one source with buffer in linear fashion should be easier on CPU cache.
* Replaced the `dead` flag and `retain` with a much dumber way to drop sounds (also using `swap_remove` since we don't care about ordering).
* `unsafe` transform of the buffer to `&mut [[f32; 2]]` to help with some bounds checks.