### PR TITLE
Even faster fill

### DIFF
--- a/src/alsa_snd.rs
+++ b/src/alsa_snd.rs
@@ -148,9 +148,9 @@ impl AudioContext {
     pub fn new() -> AudioContext {
         use crate::mixer::Mixer;
 
-        let (mixer, mixer_ctrl) = Mixer::new();
+        let (mixer_builder, mixer_ctrl) = Mixer::new();
         std::thread::spawn(move || unsafe {
-            audio_thread(mixer);
+            audio_thread(mixer_builder.build());
         });
 
         AudioContext { mixer_ctrl }

--- a/src/coreaudio_snd.rs
+++ b/src/coreaudio_snd.rs
@@ -43,8 +43,8 @@ impl AudioContext {
     pub fn new() -> AudioContext {
         use crate::mixer::{self, Mixer};
 
-        let (mixer, mixer_ctrl) = Mixer::new();
-        let mixer = Box::new(mixer);
+        let (mixer_builder, mixer_ctrl) = Mixer::new();
+        let mixer = Box::new(mixer_builder.build());
 
         unsafe {
             let fmt = _saudio_AudioStreamBasicDescription {

--- a/src/mixer.rs
+++ b/src/mixer.rs
@@ -1,8 +1,8 @@
 use crate::PlaySoundParams;
 
 use std::collections::HashMap;
-use std::sync::mpsc;
 use std::rc::Rc;
+use std::sync::mpsc;
 
 enum AudioMessage {
     AddSound(usize, Vec<f32>),
@@ -99,10 +99,7 @@ impl Mixer {
     pub fn new() -> (MixerBuilder, MixerControl) {
         let (tx, rx) = mpsc::channel();
 
-        (
-            MixerBuilder { rx },
-            MixerControl { tx, id: 0 },
-        )
+        (MixerBuilder { rx }, MixerControl { tx, id: 0 })
     }
 
     pub fn fill_audio_buffer(&mut self, buffer: &mut [f32], frames: usize) {

--- a/src/mixer.rs
+++ b/src/mixer.rs
@@ -143,7 +143,6 @@ impl Mixer {
 
         while let Some(sound) = self.mixer_state.get_mut(i) {
             let volume = sound.volume;
-            let mut remove = false;
             let mut remainder = buffer.len();
 
             loop {

--- a/src/mixer.rs
+++ b/src/mixer.rs
@@ -20,8 +20,6 @@ pub struct SoundState {
     volume: f32,
 }
 
-unsafe impl Send for SoundState {}
-
 impl SoundState {
     fn get_samples(&mut self, n: usize) -> &[f32] {
         let data = &self.data[self.sample..];

--- a/src/mixer.rs
+++ b/src/mixer.rs
@@ -199,11 +199,14 @@ pub fn load_samples_from_file(bytes: &[u8]) -> Result<Vec<f32>, ()> {
 
     // stupid nearest-neighbor resampler
     if sample_rate != 44100 {
-        let new_length = ((44100 as f32 / sample_rate as f32) * frames.len() as f32) as usize;
+        let mut new_length = ((44100 as f32 / sample_rate as f32) * frames.len() as f32) as usize;
+
+        // `new_length` must be an even number
+        new_length -= new_length % 2;
 
         let mut resampled = vec![0.0; new_length];
 
-        for (n, sample) in resampled.chunks_mut(2).enumerate() {
+        for (n, sample) in resampled.chunks_exact_mut(2).enumerate() {
             let ix = 2 * ((n as f32 / new_length as f32) * frames.len() as f32) as usize;
             sample[0] = frames[ix];
             sample[1] = frames[ix + 1];

--- a/src/mixer.rs
+++ b/src/mixer.rs
@@ -14,10 +14,10 @@ enum AudioMessage {
 pub struct SoundState {
     id: usize,
     sample: usize,
-    // Note on safety: this borrows a `Vec` inside the `HashMap`.
-    // Moving the `Vec` inside the `HashMap` doesn't affect pointer,
+    // Note on safety: this borrows a `Vec` from inside the `HashMap`.
+    // Moving the `Vec` inside the `HashMap` doesn't affect pointer
     // safety here at all, but we have to make sure to remove this
-    // `SoundState` before the `Vec` is removed.
+    // `SoundState` before the `Vec` is removed in the future.
     data: *const [f32],
     looped: bool,
     volume: f32,

--- a/src/opensles_snd.rs
+++ b/src/opensles_snd.rs
@@ -407,9 +407,9 @@ impl AudioContext {
 
         let (tx1, rx1) = mpsc::channel();
 
-        let (mixer, mixer_ctrl) = Mixer::new();
+        let (mixer_builder, mixer_ctrl) = Mixer::new();
         std::thread::spawn(move || unsafe {
-            audio_thread(mixer, rx1);
+            audio_thread(mixer_builder.build(), rx1);
         });
 
         AudioContext { mixer_ctrl, tx1 }

--- a/src/wasapi_snd.rs
+++ b/src/wasapi_snd.rs
@@ -192,9 +192,9 @@ impl AudioContext {
     pub fn new() -> AudioContext {
         use crate::mixer::Mixer;
 
-        let (mixer, mixer_ctrl) = Mixer::new();
+        let (mixer_builder, mixer_ctrl) = Mixer::new();
         std::thread::spawn(move || unsafe {
-            audio_thread(mixer);
+            audio_thread(mixer_builder.build());
         });
 
         AudioContext { mixer_ctrl }


### PR DESCRIPTION
* Converted sound data from `Vec<[f32; 2]>` to plain `Vec<f32>`, while this is a bit more error prone when it comes to resampling, it's easier to work with everywhere else.
* Added `*const [f32]` to `SoundState` which borrows data directly from the `HashMap`, so we never have to hit it when just filling the buffer.
* Filling the buffer now happens in batches up to complete size of the buffer (if source is long enough), which makes the iterations shorter and makes it a nice target for SIMD in the future (assuming the misalignment of the two buffers isn't much of an issue).

Overall this drops `fill_audio_buffer` further down to around 2µs for one track on my hardware.