### PR TITLE
Multiple playback

### DIFF
--- a/js/audio.js
+++ b/js/audio.js
@@ -1,16 +1,20 @@
+"use strict";
+
 const AudioContext = window.AudioContext || window.webkitAudioContext;
 let audio_context;
-let sounds = {};
-let audio_next_handle = 1;
+let sounds = new Map();
+let playbacks = [];
+let sound_key_next = 1;
+let playback_key_next = 1;
 
 function audio_init() {
     if (audio_context == null) {
         audio_context = new AudioContext();
-        audio_listener = audio_context.listener;
+        let audio_listener = audio_context.listener;
 
         {
-            let audioContext = window.AudioContext || window.webkitAudioContext;
-            ctx = new audioContext();
+            let AudioContext = window.AudioContext || window.webkitAudioContext;
+            let ctx = new AudioContext();
             var fixAudioContext = function (e) {
                 console.log("fix");
 
@@ -60,13 +64,11 @@ function audio_init() {
 function audio_add_buffer(content, content_len) {
     let content_array = wasm_memory.buffer.slice(content, content + content_len);
 
-    let sound_key = audio_next_handle;
-    audio_next_handle += 1;
-
-    sounds[sound_key] = {};
+    let sound_key = sound_key_next;
+    sound_key_next += 1;
 
     audio_context.decodeAudioData(content_array, function(buffer) {
-        sounds[sound_key].buffer = buffer;
+        sounds.set(sound_key, buffer);
     }, function(e) {
         // fail
         console.error("Failed to decode audio buffer", e);
@@ -78,105 +80,107 @@ function audio_source_is_loaded(sound_key) {
     return (sound_key in sounds) && sounds[sound_key].buffer != undefined;
 }
 
-function audio_play_buffer(sound_key, volume_l, volume_r, speed, repeat) {
-    audio_source_stop(sound_key);
+function recycle_playback() {
+    let playback = playbacks.find(playback => playback.sound_key === 0);
 
-    var sound = sounds[sound_key];
-    let source = audio_context.createBufferSource();
-    source.loop = repeat;
-
-    let gain_node_l = null;
-    let gain_node_r = null;
-    let merger = null;
-
-    if (volume_l != 1.0 || volume_r != 1.0) {
-        gain_node_l = audio_context.createGain();
-        source.connect(gain_node_l);
-        gain_node_r = audio_context.createGain();
-        source.connect(gain_node_r);
-
-        let merger = audio_context.createChannelMerger(2);
-        gain_node_l.connect(merger, 0, 0);
-        gain_node_r.connect(merger, 0, 1);
-        merger.connect(audio_context.destination);
-
-        gain_node_l.gain.value = volume_l;
-        gain_node_r.gain.value = volume_r;
-
-        sound.merger = merger;
+    if (playback != null) {
+        playback.source = audio_context.createBufferSource();
     } else {
-        source.connect(audio_context.destination);
-    }
-    source.playbackRate.value = speed;
+        playback = {
+            sound_key: 0,
+            playback_key: 0,
+            source: audio_context.createBufferSource(),
+            merger: audio_context.createChannelMerger(2),
+            gain_node_l: audio_context.createGain(),
+            gain_node_r: audio_context.createGain(),
+            ended: null,
+        };
 
-    sound.source = source;
-    sound.gains = [gain_node_l, gain_node_r];
-
-    source.onended = function() {
-        source.disconnect();
-        if (gain_node_l) {
-            gain_node_l.disconnect();
-        }
-        if (gain_node_r) {
-            gain_node_r.disconnect();
-        }
-        if (merger) {
-            merger.disconnect();
-        }
+        playbacks.push(playback);
     }
 
-    source.buffer = sound.buffer;
+    return playback;
+}
+
+function stop(playback) {
     try {
-	source.start(0);
+        playback.source.removeEventListener('ended', playback.ended);
+
+        playback.source.disconnect();
+        playback.gain_node_l.disconnect();
+        playback.gain_node_r.disconnect();
+        playback.merger.disconnect();
+
+        playback.sound_key = 0;
+        playback.playback_key = 0;
     } catch (e) {
-	console.error("Error starting sound", e);
+        console.error("Error stopping sound", e);
     }
+}
+
+function audio_play_buffer(sound_key, volume_l, volume_r, speed, repeat) {
+    let playback_key = playback_key_next++;
+
+    let pb = recycle_playback();
+
+    pb.sound_key = sound_key;
+    pb.playback_key = playback_key;
+
+    pb.source.connect(pb.gain_node_l);
+    pb.source.connect(pb.gain_node_r);
+    pb.gain_node_l.connect(pb.merger, 0, 0);
+    pb.gain_node_r.connect(pb.merger, 0, 1);
+    pb.merger.connect(audio_context.destination);
+
+    pb.gain_node_l.gain.value = volume_l;
+    pb.gain_node_r.gain.value = volume_r;
+
+    pb.source.playbackRate.value = speed;
+    pb.source.loop = repeat;
+
+    pb.ended = function() {
+        stop(pb);
+    };
+    pb.source.addEventListener('ended', pb.ended);
+
+    try {
+        pb.source.buffer = sounds.get(sound_key);
+        pb.source.start(0);
+    } catch (e) {
+        console.error("Error starting sound", e);
+    }
+
+    return playback_key;
 }
 
 function audio_source_set_volume(sound_key, volume_l, volume_r) {
-    if (!(sound_key in sounds)) {
-        return;
-    }
-
-    let gain_nodes = sounds[sound_key].gains;
-    let ramp_end_time = audio_context.currentTime + 1.0 / 120.0;
-
-    gain_nodes[0].gain.linearRampToValueAtTime(volume_l, ramp_end_time);
-    gain_nodes[1].gain.linearRampToValueAtTime(volume_r, ramp_end_time);
+    playbacks.forEach(playback => {
+        if (playback.sound_key === sound_key) {
+            playback.gain_node_l.gain.value = volume_l;
+            playback.gain_node_r.gain.value = volume_r;
+        }
+    });
 }
 
 function audio_source_stop(sound_key) {
-    if (!(sound_key in sounds)) {
-        console.log("stopping already remvoed sound")
-        return;
-    }
-    
-    // sound was not started or already finished by itself, this is fine
-    if (sounds[sound_key].source == undefined) {
-        return;
-    }
+    playbacks.forEach(playback => {
+        playback.sound_key === sound_key && stop(playback);
+    });
+}
 
-    try {
-        sounds[sound_key].source.stop();
-        sounds[sound_key].source.disconnect();
-        for (node of sounds[sound_key].gains) {
-            // null is a valid state when no volume manipulation applied to the sound
-            if (node != null) {
-                node.disconnect();
-            }
-        }
+function audio_playback_stop(playback_key) {
+    let playback = playbacks.find(playback => playback.playback_key === playback_key);
 
-        if (sounds[sound_key].merger) {
-            sounds[sound_key].merger.disconnect();
-        }
+    playback != null && stop(playback);
+}
 
+function audio_playback_set_volume(playback_key, volume_l, volume_r) {
+    let playback = playbacks.find(playback => playback.playback_key === playback_key);
+
+    if (playback != null) {
+        playback.gain_node_l.gain.value = volume_l;
+        playback.gain_node_r.gain.value = volume_r;
     }
-    catch (e) {
-        console.error("Error stopping sound", e);
-    }
-
-    delete sounds[sound_key].source;
-    delete sounds[sound_key].gains;
 }
 
 function register_plugin(importObject) {
@@ -186,6 +190,8 @@ function register_plugin(importObject) {
     importObject.env.audio_source_is_loaded = audio_source_is_loaded;
     importObject.env.audio_source_set_volume = audio_source_set_volume;
     importObject.env.audio_source_stop = audio_source_stop;
+    importObject.env.audio_playback_stop = audio_playback_stop;
+    importObject.env.audio_playback_set_volume = audio_playback_set_volume;
 }
 
 miniquad_add_plugin({ register_plugin, version: "0.1.0", name: "macroquad_audio" });

--- a/src/alsa_snd.rs
+++ b/src/alsa_snd.rs
@@ -158,7 +158,7 @@ impl AudioContext {
 }
 
 pub struct Sound {
-    id: usize,
+    id: u32,
 }
 
 impl Sound {

--- a/src/alsa_snd.rs
+++ b/src/alsa_snd.rs
@@ -6,6 +6,8 @@ use quad_alsa_sys as sys;
 
 use std::sync::mpsc;
 
+pub use crate::mixer::Playback;
+
 mod consts {
     pub const DEVICES: &[&str] = &["default\0", "pipewire\0"];
     pub const RATE: u32 = 44100;
@@ -141,7 +143,7 @@ unsafe fn audio_thread(mut mixer: crate::mixer::Mixer) {
 }
 
 pub struct AudioContext {
-    mixer_ctrl: crate::mixer::MixerControl,
+    pub(crate) mixer_ctrl: crate::mixer::MixerControl,
 }
 
 impl AudioContext {
@@ -158,25 +160,25 @@ impl AudioContext {
 }
 
 pub struct Sound {
-    id: u32,
+    sound_id: u32,
 }
 
 impl Sound {
     pub fn load(ctx: &mut AudioContext, data: &[u8]) -> Sound {
-        let id = ctx.mixer_ctrl.load(data);
+        let sound_id = ctx.mixer_ctrl.load(data);
 
-        Sound { id }
+        Sound { sound_id }
     }
 
-    pub fn play(&mut self, ctx: &mut AudioContext, params: PlaySoundParams) {
-        ctx.mixer_ctrl.play(self.id, params);
+    pub fn play(&mut self, ctx: &mut AudioContext, params: PlaySoundParams) -> Playback {
+        ctx.mixer_ctrl.play(self.sound_id, params)
     }
 
     pub fn stop(&mut self, ctx: &mut AudioContext) {
-        ctx.mixer_ctrl.stop(self.id);
+        ctx.mixer_ctrl.stop_all(self.sound_id);
     }
 
     pub fn set_volume(&mut self, ctx: &mut AudioContext, volume: f32) {
-        ctx.mixer_ctrl.set_volume(self.id, volume);
+        ctx.mixer_ctrl.set_volume_all(self.sound_id, volume);
     }
 }

--- a/src/coreaudio_snd.rs
+++ b/src/coreaudio_snd.rs
@@ -97,7 +97,7 @@ impl AudioContext {
 }
 
 pub struct Sound {
-    id: usize,
+    id: u32,
 }
 
 impl Sound {

--- a/src/coreaudio_snd.rs
+++ b/src/coreaudio_snd.rs
@@ -2,6 +2,8 @@ use crate::PlaySoundParams;
 
 use std::sync::mpsc;
 
+pub use crate::mixer::Playback;
+
 #[path = "coreaudio/coreaudio.rs"]
 mod coreaudio;
 
@@ -20,7 +22,7 @@ mod consts {
 }
 
 pub struct AudioContext {
-    mixer_ctrl: crate::mixer::MixerControl,
+    pub(crate) mixer_ctrl: crate::mixer::MixerControl,
 }
 
 unsafe extern "C" fn saudio_coreaudio_callback(
@@ -107,15 +109,15 @@ impl Sound {
         Sound { id }
     }
 
-    pub fn play(&mut self, ctx: &mut AudioContext, params: PlaySoundParams) {
-        ctx.mixer_ctrl.play(self.id, params);
+    pub fn play(&mut self, ctx: &mut AudioContext, params: PlaySoundParams) -> Playback {
+        ctx.mixer_ctrl.play(self.id, params)
     }
 
     pub fn stop(&mut self, ctx: &mut AudioContext) {
-        ctx.mixer_ctrl.stop(self.id);
+        ctx.mixer_ctrl.stop_all(self.id);
     }
 
     pub fn set_volume(&mut self, ctx: &mut AudioContext, volume: f32) {
-        ctx.mixer_ctrl.set_volume(self.id, volume);
+        ctx.mixer_ctrl.set_volume_all(self.id, volume);
     }
 }

--- a/src/dummy_snd.rs
+++ b/src/dummy_snd.rs
@@ -1,23 +1,33 @@
 use crate::PlaySoundParams;
 
-pub struct AudioContext {}
+pub struct AudioContext;
 
 impl AudioContext {
     pub fn new() -> AudioContext {
-        AudioContext {}
+        AudioContext
     }
 }
 
-pub struct Sound {}
+pub struct Playback;
+
+impl Playback {
+    pub fn stop(self, _ctx: &mut AudioContext) {}
+
+    pub fn set_volume(&mut self, _ctx: &mut AudioContext) {}
+}
+
+pub struct Sound;
 
 impl Sound {
     pub fn load(_data: &[u8]) -> Sound {
-        Sound {}
+        Sound
     }
 
-    pub fn play(&mut self, _ctx: &mut AudioContext, _params: PlaySoundParams) {}
+    pub fn play(&mut self, _ctx: &mut AudioContext, _params: PlaySoundParams) -> Playback {
+        Playback
+    }
 
     pub fn stop(&mut self, _ctx: &mut AudioContext) {}
 
-    pub fn set_volume(&mut self, _volume: f32) {}
+    pub fn set_volume(&mut self, _ctx: &mut AudioContext, _volume: f32) {}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ mod snd;
 #[cfg(not(target_arch = "wasm32"))]
 mod mixer;
 
-pub use snd::{AudioContext, Sound};
+pub use snd::{AudioContext, Sound, Playback};
 
 pub struct PlaySoundParams {
     pub looped: bool,

--- a/src/mixer.rs
+++ b/src/mixer.rs
@@ -143,7 +143,6 @@ impl Mixer {
 
         while let Some(sound) = self.mixer_state.get_mut(i) {
             let volume = sound.volume;
-            let mut remove = false;
             let mut remainder = buffer.len();
 
             loop {

--- a/src/mixer.rs
+++ b/src/mixer.rs
@@ -14,10 +14,10 @@ enum AudioMessage {
 pub struct SoundState {
     id: usize,
     sample: usize,
-    // Note on safety: this borrows a `Vec` inside the `HashMap`.
-    // Moving the `Vec` inside the `HashMap` doesn't affect pointer,
+    // Note on safety: this borrows a `Vec` from inside the `HashMap`.
+    // Moving the `Vec` inside the `HashMap` doesn't affect pointer
     // safety here at all, but we have to make sure to remove this
-    // `SoundState` before the `Vec` is removed.
+    // `SoundState` before the `Vec` is removed in the future.
     data: *const [f32],
     looped: bool,
     volume: f32,

--- a/src/opensles_snd.rs
+++ b/src/opensles_snd.rs
@@ -425,7 +425,7 @@ impl AudioContext {
 }
 
 pub struct Sound {
-    id: usize,
+    id: u32,
 }
 
 impl Sound {

--- a/src/opensles_snd.rs
+++ b/src/opensles_snd.rs
@@ -2,6 +2,8 @@ use crate::PlaySoundParams;
 
 use std::sync::mpsc;
 
+pub use crate::mixer::Playback;
+
 // Slightly reduced OpenSLES implementation
 // from an amazing "audir" library: https://github.com/norse-rs/audir/
 // and a little bit of glue code to make it work with macroquad
@@ -435,15 +437,15 @@ impl Sound {
         Sound { id }
     }
 
-    pub fn play(&mut self, ctx: &mut AudioContext, params: PlaySoundParams) {
-        ctx.mixer_ctrl.play(self.id, params);
+    pub fn play(&mut self, ctx: &mut AudioContext, params: PlaySoundParams) -> Playback {
+        ctx.mixer_ctrl.play(self.id, params)
     }
 
     pub fn stop(&mut self, ctx: &mut AudioContext) {
-        ctx.mixer_ctrl.stop(self.id);
+        ctx.mixer_ctrl.stop_all(self.id);
     }
 
     pub fn set_volume(&mut self, ctx: &mut AudioContext, volume: f32) {
-        ctx.mixer_ctrl.set_volume(self.id, volume);
+        ctx.mixer_ctrl.set_volume_all(self.id, volume);
     }
 }

--- a/src/wasapi_snd.rs
+++ b/src/wasapi_snd.rs
@@ -3,6 +3,8 @@
 
 use crate::PlaySoundParams;
 
+pub use crate::mixer::Playback;
+
 use winapi::shared::guiddef::{CLSID, IID};
 use winapi::shared::ksmedia;
 use winapi::shared::minwindef::*;
@@ -212,15 +214,15 @@ impl Sound {
         Sound { id }
     }
 
-    pub fn play(&mut self, ctx: &mut AudioContext, params: PlaySoundParams) {
-        ctx.mixer_ctrl.play(self.id, params);
+    pub fn play(&mut self, ctx: &mut AudioContext, params: PlaySoundParams) -> Playback {
+        ctx.mixer_ctrl.play(self.id, params)
     }
 
     pub fn stop(&mut self, ctx: &mut AudioContext) {
-        ctx.mixer_ctrl.stop(self.id);
+        ctx.mixer_ctrl.stop_all(self.id);
     }
 
     pub fn set_volume(&mut self, ctx: &mut AudioContext, volume: f32) {
-        ctx.mixer_ctrl.set_volume(self.id, volume);
+        ctx.mixer_ctrl.set_volume_all(self.id, volume);
     }
 }

--- a/src/wasapi_snd.rs
+++ b/src/wasapi_snd.rs
@@ -202,7 +202,7 @@ impl AudioContext {
 }
 
 pub struct Sound {
-    id: usize,
+    id: u32,
 }
 
 impl Sound {

--- a/src/web_snd.rs
+++ b/src/web_snd.rs
@@ -32,6 +32,18 @@ impl AudioContext {
 
 pub struct Sound(u32);
 
+pub struct Playback(u32);
+
+impl Playback {
+    pub fn stop(self, _ctx: &mut AudioContext) {
+        // ctx.mixer_ctrl.send(AudioMessage::Stop(self.play_id));
+    }
+
+    pub fn set_volume(&mut self, _ctx: &mut AudioContext, volume: f32) {
+        // ctx.mixer_ctrl.send(AudioMessage::SetVolume(self.play_id, volume));
+    }
+}
+
 impl Sound {
     pub fn load(_ctx: &mut AudioContext, data: &[u8]) -> Sound {
         let buffer = unsafe { audio_add_buffer(data.as_ptr(), data.len() as u32) };
@@ -51,8 +63,10 @@ impl Sound {
         unsafe { audio_source_is_loaded(self.0) }
     }
 
-    pub fn play(&mut self, _ctx: &mut AudioContext, params: PlaySoundParams) {
-        unsafe { audio_play_buffer(self.0, params.volume, params.volume, 1.0, params.looped) }
+    pub fn play(&mut self, _ctx: &mut AudioContext, params: PlaySoundParams) -> Playback {
+        unsafe { audio_play_buffer(self.0, params.volume, params.volume, 1.0, params.looped) };
+
+        Playback(0)
     }
 
     pub fn stop(&mut self, _ctx: &mut AudioContext) {


### PR DESCRIPTION
As per #41 this PR adds the ability to play multiples of the same sound in parallel, each `play` now returns a `Playback` struct that allows each individual instance of a sound to be stopped (or having its volume changed) independently from any other. `Sound::stop` and `Sound::set_volume` can still be used affects all instances of a sound, even if `Playback` was dropped.

This includes all changes from #40, so might want to merge that one first.

