### PR TITLE
Wait for PCM to be ready before writing

### DIFF
--- a/src/alsa_snd.rs
+++ b/src/alsa_snd.rs
@@ -104,6 +104,11 @@ unsafe fn audio_thread(mut mixer: crate::mixer::Mixer) {
     let pcm_handle = setup_pcm_device();
 
     loop {
+        // Wait for PCM to be ready for next write (no timeout)
+        if sys::snd_pcm_wait(pcm_handle, -1) < 0 {
+            panic!("PCM device is not ready");
+        }
+
         // // find out how much space is available for playback data
         // teoretically it should reduce latency - we will fill a minimum amount of
         // frames just to keep alsa busy and will be able to mix some fresh sounds


### PR DESCRIPTION
Pop!_OS has fixed the missing default setting for Alsa, but it was set to pulseaudio instead of pipewire.

This PR fixes an issue where attempt to write frames to pulseaudio would crash/block the audio thread. Adding this wait fixes it, please don't ask me why, I've no idea what I'm doing here. Tested both pulse and pipewire with the change and both are working.