### PR TITLE
Make sure wasm JS exports don't clash with another plugin

### DIFF
--- a/js/audio.js
+++ b/js/audio.js
@@ -177,16 +177,15 @@ function audio_playback_set_volume(playback_key, volume) {
     }
 }
 
-function register_plugin(importObject) {
-    importObject.env.audio_init = audio_init;
-    importObject.env.audio_add_buffer = audio_add_buffer;
-    importObject.env.audio_play_buffer = audio_play_buffer;
-    importObject.env.audio_source_is_loaded = audio_source_is_loaded;
-    importObject.env.audio_source_set_volume = audio_source_set_volume;
-    importObject.env.audio_source_stop = audio_source_stop;
-    importObject.env.audio_source_delete = audio_source_delete;
-    importObject.env.audio_playback_stop = audio_playback_stop;
-    importObject.env.audio_playback_set_volume = audio_playback_set_volume;
-}
-
-miniquad_add_plugin({ register_plugin, version: 1, name: "macroquad_audio" });
+miniquad_add_plugin({
+    register_plugin: function (importObject) {
+        importObject.env.audio_init = audio_init;
+        importObject.env.audio_add_buffer = audio_add_buffer;
+        importObject.env.audio_play_buffer = audio_play_buffer;
+        importObject.env.audio_source_is_loaded = audio_source_is_loaded;
+        importObject.env.audio_source_set_volume = audio_source_set_volume;
+        importObject.env.audio_source_stop = audio_source_stop;
+        importObject.env.audio_source_delete = audio_source_delete;
+        importObject.env.audio_playback_stop = audio_playback_stop;
+        importObject.env.audio_playback_set_volume = audio_playback_set_volume;
+}, version: 1, name: "macroquad_audio" });


### PR DESCRIPTION
Previously: when concatenating all JS files from various different plugins, if there's another register_plugin function defined, then the later-defined function will override this one (due to JS function hoisting).

For example, in my case the `sapp_jsutils` plugin was also defining a function called `register_plugin`, which meant that the `sapp_jsutils` plugin's JS functions were getting registered twice and the `macroquad_audio` plugin's functions weren't getting registered at all. That will cause console error messages saying various JS functions defined by this plugin are missing, and of course prevents playing audio.

Now, by avoiding referencing a `register_plugin` function by name, we are a bit more robust against that happening.