### PR TITLE
specify alsa period size, preventing buffer underrun panics

### DIFF
--- a/src/alsa_snd.rs
+++ b/src/alsa_snd.rs
@@ -13,6 +13,7 @@ mod consts {
     pub const RATE: u32 = 44100;
     pub const CHANNELS: u32 = 2;
     pub const PCM_BUFFER_SIZE: ::std::os::raw::c_ulong = 4096;
+    pub const PCM_PERIOD_SIZE: ::std::os::raw::c_ulong = PCM_BUFFER_SIZE / 4; /* Send interrupt every 1024 (stereo) frames. */
 }
 
 unsafe fn setup_pcm_device() -> *mut sys::snd_pcm_t {
@@ -53,6 +54,15 @@ unsafe fn setup_pcm_device() -> *mut sys::snd_pcm_t {
             < 0
         {
             panic!("Cannot set buffer size.");
+        }
+        if sys::snd_pcm_hw_params_set_period_size(
+            pcm_handle,
+            hw_params,
+            consts::PCM_PERIOD_SIZE,
+            0, /* equal to, not smaller, not bigger */
+        ) < 0
+        {
+            panic!("Cannot set period size.");
         }
         if sys::snd_pcm_hw_params_set_channels(pcm_handle, hw_params, consts::CHANNELS) < 0 {
             panic!("Cannot set channels number.");

--- a/src/alsa_snd.rs
+++ b/src/alsa_snd.rs
@@ -30,69 +30,85 @@ unsafe fn setup_pcm_device() -> *mut sys::snd_pcm_t {
         panic!("Can't open PCM device.");
     }
 
-    let mut hw_params: *mut sys::snd_pcm_hw_params_t = std::ptr::null_mut();
-    sys::snd_pcm_hw_params_malloc(&mut hw_params);
-    sys::snd_pcm_hw_params_any(pcm_handle, hw_params);
-
-    if sys::snd_pcm_hw_params_set_access(pcm_handle, hw_params, sys::SND_PCM_ACCESS_RW_INTERLEAVED)
-        < 0
+    // Set hardware parameters
     {
-        panic!("Can't set interleaved mode");
+        let mut hw_params: *mut sys::snd_pcm_hw_params_t = std::ptr::null_mut();
+        sys::snd_pcm_hw_params_malloc(&mut hw_params);
+        sys::snd_pcm_hw_params_any(pcm_handle, hw_params);
+
+        if sys::snd_pcm_hw_params_set_access(
+            pcm_handle,
+            hw_params,
+            sys::SND_PCM_ACCESS_RW_INTERLEAVED,
+        ) < 0
+        {
+            panic!("Cannot set interleaved mode.");
+        }
+        if sys::snd_pcm_hw_params_set_format(pcm_handle, hw_params, sys::SND_PCM_FORMAT_FLOAT_LE)
+            < 0
+        {
+            panic!("Cannot set SND_PCM_FORMAT_FLOAT_LE format.");
+        }
+        if sys::snd_pcm_hw_params_set_buffer_size(pcm_handle, hw_params, consts::PCM_BUFFER_SIZE)
+            < 0
+        {
+            panic!("Cannot set buffer size.");
+        }
+        if sys::snd_pcm_hw_params_set_channels(pcm_handle, hw_params, consts::CHANNELS) < 0 {
+            panic!("Cannot set channels number.");
+        }
+
+        let mut rate = consts::RATE;
+        if sys::snd_pcm_hw_params_set_rate_near(
+            pcm_handle,
+            hw_params,
+            &mut rate,
+            std::ptr::null_mut(),
+        ) < 0
+        {
+            panic!("Cannot set rate.");
+        }
+
+        // Write parameters
+        if sys::snd_pcm_hw_params(pcm_handle, hw_params) < 0 {
+            panic!("Cannot set harware parameters.");
+        }
+        sys::snd_pcm_hw_params_free(hw_params);
     }
 
-    if sys::snd_pcm_hw_params_set_format(pcm_handle, hw_params, sys::SND_PCM_FORMAT_FLOAT_LE) < 0 {
-        panic!("Can't set SND_PCM_FORMAT_FLOAT_LE format");
-    }
-    if sys::snd_pcm_hw_params_set_buffer_size(pcm_handle, hw_params, consts::PCM_BUFFER_SIZE) < 0 {
-        panic!("Cant's set buffer size");
-    }
-    if sys::snd_pcm_hw_params_set_channels(pcm_handle, hw_params, consts::CHANNELS) < 0 {
-        panic!("Can't set channels number.");
-    }
-
-    let mut rate = consts::RATE;
-    if sys::snd_pcm_hw_params_set_rate_near(pcm_handle, hw_params, &mut rate, std::ptr::null_mut())
-        < 0
+    // Set software parameters
     {
-        panic!("Can't set rate.");
-    }
+        // Tell ALSA to wake us up whenever AudioContext::PCM_BUFFER_SIZE or more frames
+        //   of playback data can be delivered. Also, tell
+        //   ALSA that we'll start the device ourselves.
+        let mut sw_params: *mut sys::snd_pcm_sw_params_t = std::ptr::null_mut();
 
-    // Write parameters
-    if sys::snd_pcm_hw_params(pcm_handle, hw_params) < 0 {
-        panic!("Can't set harware parameters.");
-    }
-    sys::snd_pcm_hw_params_free(hw_params);
+        if sys::snd_pcm_sw_params_malloc(&mut sw_params) < 0 {
+            panic!("Cannot allocate software parameters structure.");
+        }
+        if sys::snd_pcm_sw_params_current(pcm_handle, sw_params) < 0 {
+            panic!("Cannot initialize software parameters structure.");
+        }
 
-    // tell ALSA to wake us up whenever AudioContext::PCM_BUFFER_SIZE or more frames
-    //   of playback data can be delivered. Also, tell
-    //   ALSA that we'll start the device ourselves.
-    let mut sw_params: *mut sys::snd_pcm_sw_params_t = std::ptr::null_mut();
-
-    if sys::snd_pcm_sw_params_malloc(&mut sw_params) < 0 {
-        panic!("cannot allocate software parameters structure");
+        // if sys::snd_pcm_sw_params_set_avail_min(
+        //     pcm_handle,
+        //     sw_params,
+        //     AudioContext::PCM_BUFFER_SIZE,
+        // ) < 0
+        // {
+        //     panic!("cannot set minimum available count");
+        // }
+        if sys::snd_pcm_sw_params_set_start_threshold(pcm_handle, sw_params, 0) < 0 {
+            panic!("Cannot set start mode.");
+        }
+        if sys::snd_pcm_sw_params(pcm_handle, sw_params) < 0 {
+            panic!("Cannot set software parameters.");
+        }
+        sys::snd_pcm_sw_params_free(sw_params);
     }
-    if sys::snd_pcm_sw_params_current(pcm_handle, sw_params) < 0 {
-        panic!("cannot initialize software parameters structure");
-    }
-
-    // if sys::snd_pcm_sw_params_set_avail_min(
-    //     pcm_handle,
-    //     sw_params,
-    //     AudioContext::PCM_BUFFER_SIZE,
-    // ) < 0
-    // {
-    //     panic!("cannot set minimum available count");
-    // }
-    if sys::snd_pcm_sw_params_set_start_threshold(pcm_handle, sw_params, 0) < 0 {
-        panic!("cannot set start mode");
-    }
-    if sys::snd_pcm_sw_params(pcm_handle, sw_params) < 0 {
-        panic!("cannot set software parameters");
-    }
-    sys::snd_pcm_sw_params_free(sw_params);
 
     if sys::snd_pcm_prepare(pcm_handle) < 0 {
-        panic!("cannot prepare audio interface for use");
+        panic!("Cannot prepare audio interface for use.");
     }
 
     pcm_handle


### PR DESCRIPTION
It seems that some optimized real time kernel settings lead to alsa
buffer underruns with prior implementation. The period size might delay
thread wakeup enough, such that the buffer can properly be filled
(somewhat of a fantasy explanation, not understanding how alsa actually
works ... ).

Fixes #55 .

Also, space hardware and software settings in their own blocks and make the panic messages more consistent in toning.